### PR TITLE
Fix: Q&Aに改行文字が残っていたのを修正した

### DIFF
--- a/src/components/qAndA.tsx
+++ b/src/components/qAndA.tsx
@@ -12,7 +12,7 @@ const QAndA = ({ question, answer }: Props) => {
 				Q. {question}
 			</Typography>
 			<Typography style={{ whiteSpace: "pre-line" }} sx={{ px: 2 }} variant='body1'>
-				A.{answer}
+				A. {answer.replace(/\\n/g, "\n")}
 			</Typography>
 		</Container>
 	);


### PR DESCRIPTION
改行文字が残っていたのが少し気になったので修正した。
![dorg9uh](https://github.com/user-attachments/assets/a4816d60-fc90-43f6-9358-3c4e084e64fc)
